### PR TITLE
Improved Installation Guide, Added Composer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,114 @@ Does not provide a smooth integration (yet). For now use for your own pain and r
 
 ### Concept
 
-Yii1 framework was not designed for functional testing. This bridge classes include components that override standart Yii components to be testable. The most common issues with Yii functional tests are usage `headers`, `cookies` functions in PHP code, which produce errors on testing. Also usage of `exit` directive might even stop test execution completely. 
+Yii1 framework was not designed for functional testing. This bridge classes include components that override standart Yii components to be testable. The most common issues with Yii functional tests are usage `headers`, `cookies` functions in PHP code, which produce errors on testing. Also usage of `exit` directive might even stop test execution completely.
 
 ### Install
 
-* Install [Codeception](http://codeception.com/install) and set up [Yii1](http://codeception.com/docs/modules/Yii1) module. 
-* Clone this repository into `tests/_data` directory.
-
+* Install [Codeception](http://codeception.com/install) via composer
 ```
-git clone git@github.com:Codeception/YiiBridge.git tests/_data/YiiBridge
-```
-
-* include `yiit.php` file in your `tests/_bootstrap.php`:
-
-``` php
-require_once __DIR__.'/../_data/YiiBridge/yiit.php';
-
+php composer.phar require "codeception/codeception:*"
+php composer.phar update
 ```
 
-* Done!
+* Bootstrap Codeception to ```protected/tests```
+
+```
+./vendor/bin/codecept bootstrap protected/tests
+```
+
+* And set up [Yii1](http://codeception.com/docs/modules/Yii1) module.
+
+__test.php__:
+```php
+<?php
+
+// Definitions
+defined('DS') or define('DS', DIRECTORY_SEPARATOR);
+defined('YII_DEBUG') or define('YII_DEBUG',true);
+defined('YII_TRACE_LEVEL') or define('YII_TRACE_LEVEL',3);
+
+// Load the config files
+$config = require __DIR__.DS.'protected'.DS.'config'.DS.'test.php';
+
+// Load Yii and Composer extensions
+require_once __DIR__.DS.'vendor'.DS.'yiisoft'.DS.'yii'.DS.'framework'.DS.'yii.php';
+require_once __DIR__.DS.'vendor'.DS.'autoload.php';
+
+// Return for Codeception
+return array(
+    'class' => 'CWebApplication',
+    'config' => $config,
+);
+
+```
+
+__codeception.yml__:
+```
+actor: Dev
+paths:
+    tests: protected/tests
+    log: protected/tests/_log
+    data: protected/tests/_data
+    helpers: protected/tests/_helpers
+settings:
+    bootstrap: _bootstrap.php
+    colors: true
+    memory_limit: 1024M
+    log: true
+    debug: true
+modules:
+    enabled: [PhpBrowser, WebHelper, TestHelper, Yii1]
+    config:
+        PhpBrowser:
+            url: http://localhost:8234
+        Yii1:
+            appPath: test.php
+            url: http://localhost:8234/test.php
+
+```
+
+* Install YiiBridge via Composer
+```
+php composer.phar require "codeception/YiiBridge:*"
+php composer.phar update
+```
+
+* Include composer's autoload file in your ```tests/_bootstrap.php``` file.
+```
+    require_once '/path/to/vendor/composer/autoload.php';
+```
+
+* Modify your ```protected/config/test.php``` configuration file to use the ```CodeceptionHttpRequest``` class instead of ```CHttpRequest```
+
+```php
+<?php return array(
+    [...]
+
+    'components' => array(
+
+        [...]
+
+        'request' => array(
+            'class' => 'CodeceptionHttpRequest'
+        ),
+
+        [...]
+    ),
+);
+```
+
+* Done! Use codeception normally to generate at run tests
 
 ### Important Notes
 
-This bridge is far from complete. It might not suit your project as well. So any contributions are welcome. If you feel like you need to customize any of provided classes - please do that. 
+This bridge is far from complete. It might not suit your project as well. So any contributions are welcome. If you feel like you need to customize any of provided classes - please do that.
 
 ### Known Issues and Roadmap
 
 * Sessions -> triggers php error
 * Forwards -> triggers php error
+* CLocale -> triggers error
 * Http Codes
 * WebApplication->end -> triggers `exit` directive
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,6 @@ php composer.phar require "codeception/YiiBridge:*"
 php composer.phar update
 ```
 
-* Include composer's autoload file in your ```tests/_bootstrap.php``` file.
-```
-    require_once '/path/to/vendor/composer/autoload.php';
-```
-
 * Modify your ```protected/config/test.php``` configuration file to use the ```CodeceptionHttpRequest``` class instead of ```CHttpRequest```
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "codeception/YiiBridge",
+    "description": "YiiBridge extension",
+    "license": "MIT",
+    "type": "package",
+    "minimum-stability": "dev"
+}

--- a/yiit.php
+++ b/yiit.php
@@ -2,7 +2,7 @@
 function launch_codeception_yii_bridge() {
     Yii::setPathOfAlias('codeception-yii',__DIR__);
     Yii::import('codeception-yii.test.CTestCase');
-    Yii::import('codeception-yii.yii.web.CodeceptionHttpRequest');
+    Yii::import('codeception-yii.web.CodeceptionHttpRequest');
     Yii::import('system.test.CDbTestCase');
     Yii::import('system.test.CWebTestCase');
 }


### PR DESCRIPTION
Codeception makes writing tests pretty easy and painless, unfortunately getting it working with Yii Framework is pretty painful. This pull request attempts to alleviate much of those pains by making this dependency easier to install, and by providing more detailed instructions for getting Codeception working with Yii Framework. Here's what's included.

---
### Composer Support

It doesn't make sense that Codeception provides support for Yii via composer, but this dependency has to be cloned into a project manually, so I added a single `composer.json` file so that this dependency can be installed via composer. The alias I used is `codeception/YiiBridge`. 

Ideally, whoever owns this repository would setup a [packagist](https://packagist.org) repository for `codeception/YiiBridge` so that you wouldn't also have to add a `requirements` section to your `composer.json` file.
### More Detailed Installation Instructions

The installation instructions for this were pretty sparse, and left out a few important components, specifically with getting `CodeceptionCHttpRequest` working. I've updated the README to include more detailed instructions on how to get the Yii1 module working with codeception and actually being able to run tests with it.

---

Let me know if there's anything you'd like to see in this PR.

Cheers!
Charles R. Portwood II
